### PR TITLE
cmake: Limit doxygen to include/

### DIFF
--- a/cmake/Doxygen.cmake
+++ b/cmake/Doxygen.cmake
@@ -5,7 +5,6 @@ function(enable_doxygen)
     set(DOXYGEN_CALL_GRAPH YES)
     set(DOXYGEN_EXTRACT_ALL YES)
     find_package(Doxygen REQUIRED dot)
-    doxygen_add_docs(doxygen-docs ${PROJECT_SOURCE_DIR})
-
+    doxygen_add_docs(doxygen-docs ${PROJECT_SOURCE_DIR}/include)
   endif()
 endfunction()


### PR DESCRIPTION
Closes #7. 

Limit doxygen to the include dir.